### PR TITLE
Fixed the java.lang.NumberFormatException for values like 08 and 09 that represent an invalid Octal number.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1939,8 +1939,8 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
     protected long determineInitialDelay( String initialTimeExpression ) {
         Matcher matcher = RepositoryConfiguration.INITIAL_TIME_PATTERN.matcher(initialTimeExpression);
         if (matcher.matches()) {
-            int hours = Integer.decode(matcher.group(1));
-            int mins = Integer.decode(matcher.group(2));
+            int hours = Integer.valueOf(matcher.group(1));
+            int mins = Integer.valueOf(matcher.group(2));
             LocalDateTime dateTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(hours, mins));
             long delay = dateTime.toInstant(ZoneOffset.UTC).toEpochMilli() - System.currentTimeMillis();
             if (delay <= 0L) {


### PR DESCRIPTION
Hi Andrew,
I think it'll alway throws the java.lang.NumberFormatException for numbers 08 and 09 failed for since numbers starting with 0 in methods Integer.decode(String) represents the context of an Octal number. 
I don't know why method Integer.decode(String) is used here since the format expression hh:mm looks more like the decimal format and there several ways to fix it which depends on the context of the initialTimeExpression in method JcrRepository.determineInitialDelay( String initialTimeExpression ). I've created a PR to fix it. I think you are the better person for it so I am passing it to you so that you can handle it right the way. 
Have a great weekend!

Longshou
