### PR TITLE
Fixed the local to UTC date bug that won't increase the date and the hours once it reaches the end of the UTC date.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1939,8 +1939,8 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
     protected long determineInitialDelay( String initialTimeExpression ) {
         Matcher matcher = RepositoryConfiguration.INITIAL_TIME_PATTERN.matcher(initialTimeExpression);
         if (matcher.matches()) {
-            int hours = Integer.decode(matcher.group(1));
-            int mins = Integer.decode(matcher.group(2));
+            int hours = Integer.valueOf(matcher.group(1));
+            int mins = Integer.valueOf(matcher.group(2));
             LocalDateTime dateTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(hours, mins));
             long delay = dateTime.toInstant(ZoneOffset.UTC).toEpochMilli() - System.currentTimeMillis();
             if (delay <= 0L) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1941,7 +1941,7 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
         if (matcher.matches()) {
             int hours = Integer.valueOf(matcher.group(1));
             int mins = Integer.valueOf(matcher.group(2));
-            LocalDateTime dateTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(hours, mins));
+            LocalDateTime dateTime = LocalDateTime.of(LocalDate.now(ZoneOffset.UTC), LocalTime.of(hours, mins));
             long delay = dateTime.toInstant(ZoneOffset.UTC).toEpochMilli() - System.currentTimeMillis();
             if (delay <= 0L) {
                 delay = dateTime.plusDays(1).toInstant(ZoneOffset.UTC).toEpochMilli() - System.currentTimeMillis();

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
@@ -1499,6 +1499,34 @@ public class JcrRepositoryTest {
         repository.start();
     }
 
+    @Test
+    public void allInitialDelaysShouldBeValid() throws Exception {
+        repository.determineInitialDelay("00:00");
+        repository.determineInitialDelay("01:00");
+        repository.determineInitialDelay("02:00");
+        repository.determineInitialDelay("03:00");
+        repository.determineInitialDelay("04:00");
+        repository.determineInitialDelay("05:00");
+        repository.determineInitialDelay("06:00");
+        repository.determineInitialDelay("07:00");
+        repository.determineInitialDelay("08:00");
+        repository.determineInitialDelay("09:00");
+        repository.determineInitialDelay("10:00");
+        repository.determineInitialDelay("11:00");
+        repository.determineInitialDelay("12:00");
+        repository.determineInitialDelay("13:00");
+        repository.determineInitialDelay("14:00");
+        repository.determineInitialDelay("15:00");
+        repository.determineInitialDelay("16:00");
+        repository.determineInitialDelay("17:00");
+        repository.determineInitialDelay("18:00");
+        repository.determineInitialDelay("19:00");
+        repository.determineInitialDelay("20:00");
+        repository.determineInitialDelay("21:00");
+        repository.determineInitialDelay("22:00");
+        repository.determineInitialDelay("23:00");
+    }
+
     protected void nodeExists( Session session,
                                String parentPath,
                                String childName,


### PR DESCRIPTION
Hi Andrew,
The second bug should be fixed now, see commit https://github.com/awoods/modeshape/commit/f1c7c73f8c7771cfa5abbc39e740a414a9547fa0 . I am seeing it strange that with the LocalDateTime instance constructed from LocalDate.now(), the date and hours won't incremented when it reaches 24 (00) during converting to UTC time. I think that's why it always failed at night.

Longshou
